### PR TITLE
Add Docker environment & web demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ model = torch.hub.load("facebookresearch/swag", model="vit_b16_in1k")
 
 For a tutorial with step-by-step instructions to perform inference, follow our [inference tutorial](inference_tutorial.ipynb) and run it locally, or [![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/facebookresearch/swag/blob/main/inference_tutorial.ipynb).
 
+## Replicate Demo and Docker Image
+
+SWAG web demo and docker image is on Replicate. You can try out demo with all the checkpoints here [![Replicate](https://replicate.com/facebookresearch/swag/badge)](https://replicate.com/facebookresearch/swag).
+
 ## Live Demo
 
 SWAG has been integrated into [Huggingface Spaces 🤗](https://huggingface.co/spaces) using [Gradio](https://github.com/gradio-app/gradio). Try out the web demo on [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/akhaliq/SWAG).

--- a/cog.yaml
+++ b/cog.yaml
@@ -1,0 +1,14 @@
+build:
+  gpu: true
+  cuda: "11.1"
+  python_version: "3.8"
+  system_packages:
+    - "libgl1-mesa-glx"
+    - "libglib2.0-0"
+  python_packages:
+    - "ipython==7.30.1"
+    - "torchvision==0.11.1"
+    - "torch==1.10.0"
+    - "matplotlib==3.4.3"
+
+predict: "predict.py:Predictor"

--- a/predict.py
+++ b/predict.py
@@ -1,3 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+
 """
 Download the weights in ./checkpoints and ImageNet 1K ID to class mappings beforehand
 wget https://s3.amazonaws.com/deep-learning-models/image-models/imagenet_class_index.json -O in_cls_idx.json

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,105 @@
+"""
+Download the weights in ./checkpoints and ImageNet 1K ID to class mappings beforehand
+wget https://s3.amazonaws.com/deep-learning-models/image-models/imagenet_class_index.json -O in_cls_idx.json
+"""
+import json
+from pathlib import Path
+
+import torch
+from torchvision import transforms
+from PIL import Image
+import cog
+
+from models.vision_transformer import ViTB16, ViTH14, ViTL16
+from models.regnet import RegNetY32gf, RegNetY16gf, RegNetY128gf
+
+
+class Predictor(cog.Predictor):
+    def setup(self):
+        IN1K_CLASSES = 1000
+        self.device = "cuda:0"
+        self.resolution = {
+            'vit_h14_in1k': 518,
+            'vit_l16_in1k': 512,
+            'vit_b16_in1k': 384,
+            'regnety_16gf_in1k': 384,
+            'regnety_32gf_in1k': 384,
+            'regnety_128gf_in1k': 384
+        }
+
+        vit_h14_in1k_model = ViTH14(image_size=518, num_classes=IN1K_CLASSES)
+        vit_h14_in1k_model.load_state_dict(torch.load('checkpoints/vit_h14_in1k.torch'))
+        vit_l16_in1k_model = ViTL16(image_size=512, num_classes=IN1K_CLASSES)
+        vit_l16_in1k_model.load_state_dict(torch.load('checkpoints/vit_l16_in1k.torch'))
+        vit_b16_in1k_model = ViTB16(image_size=384, num_classes=IN1K_CLASSES)
+        vit_b16_in1k_model.load_state_dict(torch.load('checkpoints/vit_b16_in1k.torch'))
+        regnety_16gf_in1k_model = RegNetY16gf(num_classes=IN1K_CLASSES)
+        regnety_16gf_in1k_model.load_state_dict(torch.load('checkpoints/regnety_16gf_in1k.torch'))
+        regnety_32gf_in1k_model = RegNetY32gf(num_classes=IN1K_CLASSES)
+        regnety_32gf_in1k_model.load_state_dict(torch.load('checkpoints/regnety_32gf_in1k.torch'))
+        regnety_128gf_in1k_model = RegNetY128gf(num_classes=IN1K_CLASSES)
+        regnety_128gf_in1k_model.load_state_dict(torch.load('checkpoints/regnety_128gf_in1k.torch'))
+        self.models = {
+            'vit_h14_in1k': vit_h14_in1k_model,
+            'vit_l16_in1k': vit_l16_in1k_model,
+            'vit_b16_in1k': vit_b16_in1k_model,
+            'regnety_16gf_in1k': regnety_16gf_in1k_model,
+            'regnety_32gf_in1k': regnety_32gf_in1k_model,
+            'regnety_128gf_in1k': regnety_128gf_in1k_model
+        }
+
+        with open("in_cls_idx.json", "r") as f:
+            self.imagenet_id_to_name = {int(cls_id): name for cls_id, (label, name) in json.load(f).items()}
+
+    @cog.input(
+        "image",
+        type=Path,
+        help="input image",
+    )
+    @cog.input(
+        "model_name",
+        type=str,
+        default='vit_h14_in1k',
+        options=['vit_h14_in1k', 'vit_l16_in1k', 'vit_b16_in1k', 'regnety_16gf_in1k', 'regnety_32gf_in1k', 'regnety_128gf_in1k'],
+        help="Choose a model type",
+    )
+    @cog.input(
+        "topk",
+        type=int,
+        min=1,
+        max=10,
+        default=5,
+        help="Choose top k predictions to return.",
+    )
+    def predict(self, image, model_name, topk):
+        resolution = self.resolution[model_name]
+        model = self.models[model_name]
+        model.to(self.device)
+        model.eval()
+
+        image = Image.open(str(image)).convert("RGB")
+        image = transform_image(image, resolution)
+        image = image.to(self.device)
+        # we do not need to track gradients for inference
+        with torch.no_grad():
+            _, preds = model(image).topk(topk)
+        preds = preds.tolist()[0]
+        return [self.imagenet_id_to_name[cls_id] for cls_id in preds]
+
+
+def transform_image(image, resolution):
+    transform = transforms.Compose([
+        transforms.Resize(
+            resolution,
+            interpolation=transforms.InterpolationMode.BICUBIC,
+        ),
+        transforms.CenterCrop(resolution),
+        transforms.ToTensor(),
+        transforms.Normalize(
+            mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+        ),
+    ])
+    image = transform(image)
+    # we also add a batch dimension to the image since that is what the model expects
+    image = image[None, :]
+    return image


### PR DESCRIPTION
This pull request makes it possible to run your model inside a Docker environment, which makes it easier for other people to run it.  We're using an open source tool called [Cog](https://github.com/replicate/cog) to make this process easier.

This also means we can make a web page where other people can try out your model! View it here: https://replicate.com/facebookresearch/swag. We enable selecting different models for inference, and you can find the docker file under the tab ‘run model with docker’. 

We have added some examples to the page, but do claim the page so you can own the page, customise the Example gallery as you like, push any future update to the web demo, and we'll feature it on our website and tweet about it too. 

In case you're wondering who I am, I'm from [Replicate](https://replicate.com/home), where we're trying to make machine learning reproducible. We got frustrated that we couldn't run all the really interesting ML work being done. So, we're going round implementing models we like. 😊